### PR TITLE
Fix documentation and hashing, add fingerprint tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `tracker` package is a lightweight web tracking service that logs and tracks user visits to specified paths on a web server. It uses Redis for storing tracking data and allows tracking users based on a generated fingerprint, which is stored in a cookie. The package provides an easy way to track page visits, the number of times a user has visited a specific path, and the user’s IP address and User-Agent.
+The `tracker` package is a lightweight web tracking service that logs and tracks user visits to specified paths on a web server. It uses Redis for storing tracking data and allows tracking users based on a generated fingerprint, which is stored in a cookie. The package provides an easy way to track page visits, the number of times a user has visited a specific path, and the user's IP address and User-Agent.
 
 ## Features
 

--- a/tracker/config/cors.go
+++ b/tracker/config/cors.go
@@ -1,12 +1,12 @@
 package config
 
-// CorsConfig represents the configuration for Redis.
+// CorsConfig represents the configuration for CORS.
 type CorsConfig struct {
 	AllowedOrigins   []string
 	AllowCredentials bool
 }
 
-// LoadCorsConfig loads the Redis configuration from environment variables.
+// LoadCorsConfig loads the CORS configuration from environment variables.
 func LoadCorsConfig() CorsConfig {
 	return CorsConfig{
 		AllowedOrigins:   getEnvAsArray("CORS_ALLOWED_ORIGINS", []string{"*"}),

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -107,6 +107,8 @@ func getIPAddress(r *http.Request) string {
 }
 
 func createFingerprint(ip string, userAgent string) string {
-	sum := sha256.Sum256([]byte(ip + userAgent))
-	return fmt.Sprintf("%x", sum)
+	h := sha256.New()
+	h.Write([]byte(ip))
+	h.Write([]byte(userAgent))
+	return fmt.Sprintf("%x", h.Sum(nil))
 }

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -1,0 +1,28 @@
+package tracker
+
+import "testing"
+
+func TestCreateFingerprintConsistency(t *testing.T) {
+	ip := "192.168.1.1"
+	ua := "TestAgent"
+
+	fp1 := createFingerprint(ip, ua)
+	fp2 := createFingerprint(ip, ua)
+
+	if fp1 != fp2 {
+		t.Fatalf("fingerprints differ for same input: %s vs %s", fp1, fp2)
+	}
+}
+
+func TestCreateFingerprintUniqueness(t *testing.T) {
+	ip := "192.168.1.1"
+	ua := "TestAgent"
+	differentUA := "OtherAgent"
+
+	fp1 := createFingerprint(ip, ua)
+	fp2 := createFingerprint(ip, differentUA)
+
+	if fp1 == fp2 {
+		t.Fatalf("fingerprints should differ for different input: %s", fp1)
+	}
+}


### PR DESCRIPTION
## Summary
- fix apostrophe typo in README
- clarify comments about CORS configuration
- compute fingerprint using a new hasher for each call
- add unit tests verifying fingerprint generation

## Testing
- `go test ./...` *(fails: missing go.sum entries)*

------
https://chatgpt.com/codex/tasks/task_e_684049168f7c8325937be02bcb754f8c